### PR TITLE
fix: fix custom repository generic params

### DIFF
--- a/src/main/java/site/devdalus/ariadne/repository/AnswerRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/AnswerRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.devdalus.ariadne.domain.Answer;
 
+import java.util.UUID;
+
 @Repository
-public interface AnswerRepository extends JpaRepository<Answer, Long> {
+public interface AnswerRepository extends JpaRepository<Answer, UUID> {
 }

--- a/src/main/java/site/devdalus/ariadne/repository/BoardRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/BoardRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, UUID> {
 }

--- a/src/main/java/site/devdalus/ariadne/repository/NodeRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/NodeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 import site.devdalus.ariadne.domain.Answer;
 import site.devdalus.ariadne.domain.Node;
 
+import java.util.UUID;
+
 @Repository
-public interface NodeRepository extends JpaRepository<Node, Long> {
+public interface NodeRepository extends JpaRepository<Node, UUID> {
 }


### PR DESCRIPTION
## 💜 TodoList
-----
- [x] Custom 레포지토리 수정

## ✅ PR Point
-----
```java
(Node, Board, Answer 모두 수정)
기존 : public interface NodeRepository extends JpaRepository<Node, Long> {}
수정 : public interface NodeRepository extends JpaRepository<Node, UUID> {}

```
* 이유: JpaRepository의 두번째 제네릭 인자는 Entity의 id의 타입이여야 함
Long으로 한다고 findAll()등에 문제가 있지는 않지만,   
findById를 했을 때 추론이 Long으로 되기 때문에 UUID를 통한 find 가 불가능함
## 😡 Trouble Shooting
-----

## 👀 Screenshot / GIF / Link
-----

## 📚 Reference
-----
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)