### PR TITLE
feat: mysql에 datetime으로 지정되던 칼럼값들을 timestamp로 명시적으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
     testCompileOnly 'org.projectlombok:lombok:1.18.30'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
 }
 

--- a/src/main/java/site/devdalus/ariadne/domain/Answer.java
+++ b/src/main/java/site/devdalus/ariadne/domain/Answer.java
@@ -37,11 +37,11 @@ public class Answer {
     private String content;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "modified_at")
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/site/devdalus/ariadne/domain/Board.java
+++ b/src/main/java/site/devdalus/ariadne/domain/Board.java
@@ -3,9 +3,6 @@ package site.devdalus.ariadne.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -28,11 +25,11 @@ public class Board {
     private String subject;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "modified_at")
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/site/devdalus/ariadne/domain/Node.java
+++ b/src/main/java/site/devdalus/ariadne/domain/Node.java
@@ -41,11 +41,11 @@ public class Node {
 
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "modified_at")
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime updatedAt;
 
     @Builder

--- a/src/main/java/site/devdalus/ariadne/repository/AnswerRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/AnswerRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.devdalus.ariadne.domain.Answer;
 
+import java.util.UUID;
+
 @Repository
-public interface AnswerRepository extends JpaRepository<Answer, Long> {
+public interface AnswerRepository extends JpaRepository<Answer, UUID> {
 }

--- a/src/main/java/site/devdalus/ariadne/repository/BoardRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/BoardRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, UUID> {
 }

--- a/src/main/java/site/devdalus/ariadne/repository/NodeRepository.java
+++ b/src/main/java/site/devdalus/ariadne/repository/NodeRepository.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Repository;
 import site.devdalus.ariadne.domain.Answer;
 import site.devdalus.ariadne.domain.Node;
 
+import java.util.UUID;
+
 @Repository
-public interface NodeRepository extends JpaRepository<Node, Long> {
+public interface NodeRepository extends JpaRepository<Node, UUID> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,18 @@
 spring:
+  profiles:
+    active: ${ACTIVE}
+
+---
+
+spring:
   config:
     activate:
       on-profile: dev
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:43306/devdalus?serverTimezone=UTC
-    username: root
-    password: 1q2w3e4r!!
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update
@@ -24,6 +30,7 @@ spring:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password:
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -33,4 +40,8 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  sql:
+    init:
+      mode: always
+
 


### PR DESCRIPTION
## 💜 TodoList
-----
- [x] ~ mysql에 datetime으로 지정되던 칼럼값들을 timestamp로 명시적으로 변경

## ✅ PR Point
-----
- columnDefinition을 통해 명시적으로 TIMESTAMP로 지정하지 않는 이상 hibernate 는
DATETIME으로 매핑해줌
- 따라서 합의한 TIMESTAMP를 사용하도록 명시
## 😡 Trouble Shooting
-----

## 👀 Screenshot / GIF / Link
-----
(columnDefinition을 지정하지 않은 modified_at은 datetime으로 매핑됨)
![image](https://github.com/DevdaIus/DevdalusBE/assets/53655119/035ad48d-3353-46c3-9402-da46b2953d91)


## 📚 Reference
-----
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)