### PR TITLE
[BACK-24] user & group & role 엔티티 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### VS Code ###
 .vscode/
+.env

--- a/src/main/java/site/devdalus/ariadne/constant/LoginType.java
+++ b/src/main/java/site/devdalus/ariadne/constant/LoginType.java
@@ -1,0 +1,5 @@
+package site.devdalus.ariadne.constant;
+
+public enum LoginType {
+    DEFAULT, GOOGLE;
+}

--- a/src/main/java/site/devdalus/ariadne/domain/Group.java
+++ b/src/main/java/site/devdalus/ariadne/domain/Group.java
@@ -1,0 +1,46 @@
+package site.devdalus.ariadne.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+public class Group {
+
+
+    @Id
+    @UuidGenerator
+    @Column(name = "group_id")
+    private UUID groupId;
+
+    @Column(name = "group_name", nullable = false)
+    private String groupName;
+
+
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Group(String groupName) {
+        this.groupName = groupName;
+    }
+}

--- a/src/main/java/site/devdalus/ariadne/domain/Role.java
+++ b/src/main/java/site/devdalus/ariadne/domain/Role.java
@@ -1,0 +1,37 @@
+package site.devdalus.ariadne.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+public class Role {
+
+
+    @Id
+    @UuidGenerator
+    @Column(name = "role_id")
+    private UUID roleId;
+
+    @Column(name = "role_name")
+    private String roleName;
+
+    @Builder
+    public Role(String roleName) {
+        this.roleName = roleName;
+    }
+
+
+}

--- a/src/main/java/site/devdalus/ariadne/domain/User.java
+++ b/src/main/java/site/devdalus/ariadne/domain/User.java
@@ -1,0 +1,57 @@
+package site.devdalus.ariadne.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import site.devdalus.ariadne.constant.LoginType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+public class User {
+    @Id
+    @UuidGenerator
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "login_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    @Column(name = "id", nullable = false)
+    private String id;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at", columnDefinition = "TIMESTAMP", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public User(String id, String password, String nickname) {
+        this.id = id;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+
+}

--- a/src/main/java/site/devdalus/ariadne/domain/User.java
+++ b/src/main/java/site/devdalus/ariadne/domain/User.java
@@ -34,7 +34,7 @@ public class User {
     @Column(name = "id", nullable = false)
     private String id;
 
-    @Column(name = "password", nullable = false)
+    @Column(name = "password")
     private String password;
 
 
@@ -47,10 +47,11 @@ public class User {
     private LocalDateTime updatedAt;
 
     @Builder
-    public User(String id, String password, String nickname) {
+    public User(String id, String password, String nickname, LoginType loginType) {
         this.id = id;
         this.password = password;
         this.nickname = nickname;
+        this.loginType = loginType;
     }
 
 

--- a/src/main/java/site/devdalus/ariadne/domain/UserGroup.java
+++ b/src/main/java/site/devdalus/ariadne/domain/UserGroup.java
@@ -1,0 +1,33 @@
+package site.devdalus.ariadne.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+public class UserGroup {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "user_group_id")
+    private UUID userGroupId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+}

--- a/src/main/java/site/devdalus/ariadne/domain/UserRole.java
+++ b/src/main/java/site/devdalus/ariadne/domain/UserRole.java
@@ -1,0 +1,33 @@
+package site.devdalus.ariadne.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+public class UserRole {
+
+
+    @Id
+    @UuidGenerator
+    @Column(name = "user_role_id")
+    private UUID userRoleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+}


### PR DESCRIPTION
## 💜 TodoList
-----
- [x] ~ user entity
- [x] ~ role entity
- [x] ~ group entity

## ✅ PR Point
-----

- 사실 양방향으로 언젠가는 구성해야할것같기도 함
  - 유저에 대해서 유저가 가지고 있는 권한들을 탐색하는 경우가 일반적이기 때문
  - 그러면 User 에 OneToMany를 다는게 정상이지만 JPA는 [OneToMany 단방향보다는 양방향을 권장함](https://dublin-java.tistory.com/51)
  - ManyToOne만 걸더라도 충분히 비즈니스로직으로 해결은 가능해서 이후 상황 고려하여 선택
- 일단 단방향으로만 설정했습니다

## 😡 Trouble Shooting
-----

## 👀 Screenshot / GIF / Link
-----

## 📚 Reference
-----
- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)